### PR TITLE
Update create options

### DIFF
--- a/borg/borg.json
+++ b/borg/borg.json
@@ -16,7 +16,7 @@
             "BorgCreate":{
                 "Enable": true,
                 "ArchivePath": "/home/user/",
-                "Options": "--stats --info --list --filter=E --compression auto,lzma,9"
+                "Options": "--stats --info --list --filter=E --files-cache ctime,size --compression auto,lzma,9"
                 },
             "BorgPrune":{
                 "Enable": true,
@@ -34,7 +34,7 @@
             "BorgCreate":{
                 "Enable": true,
                 "ArchivePath": "/data/pictures",
-                "Options": "--stats --info --list --filter=E --compression auto,lzma,9"
+                "Options": "--stats --info --list --filter=E --files-cache ctime,size --compression auto,lzma,9"
                 },
             "BorgPrune":{
                 "Enable": true,


### PR DESCRIPTION
Added ctime and size file-cache to avoid default inode cache, as it produces problems with SMB mounted files.