### PR TITLE
Add support for Telegram message threads in configuration and script

### DIFF
--- a/borg/README.md
+++ b/borg/README.md
@@ -46,6 +46,7 @@ Example:
     "Telegram":{
         "Enable": true,
         "ChatID": "-123",
+        "ThreadId": "99",
         "APIkey": "123:ABC"
         },
     "Task": [
@@ -104,6 +105,7 @@ Example:
 | GeneralConfig.Exports | text | Enable the EXPORT variables, for instance `BORG_CHECK_I_KNOW_WHAT_I_AM_DOING=YES` or `BORG_RSH="ssh -i /path/to/private/key "`. Visit https://borgbackup.readthedocs.io/en/stable/usage/general.html#environment-variables for further info about available environment variables|
 | Telegram.Enable | true / false | Enable Telegram Notifications |
 | Telegram.ChatID | number | Enable Telegram Notifications (you can get this when you add the bot @getmyid_bot to your chat/group) |
+| Telegram.ThreadId | number | _Topic_ ID in your group (you can get this when you add the bot @getmyid_bot to your chat/group) |
 | Telegram.APIkey | alphanumeric | Telegram Bot API Key |
 | Task.Repository | Path | Full path to Repository |
 | Task.BorgPassphrase | alphanumeric | Repository's password |
@@ -125,6 +127,7 @@ Telegram Messages:
 Telegram Log:
 ![Telegram Log](https://github.com/MrCaringi/assets/blob/main/images/scripts/borg/log_01.png)
 ##  Version Story
+- 2025-04-16    v1.8.0  Feature: Support API Telegram `message_thread_id` to send messages to _Topics_
 - 2023-10-29    v1.7.0  Feature: Feature: Adding Emojis to Telegram messages (✅,⚠️,🔴 and 🔘)
 - 2023-10-29    v1.6.0  Feature: Dinamic EXPORT of Variables
 - 2023-01-03    v1.5.2  Feature: TOTAL size (compact) in telegram notification/log

--- a/borg/borg.sh
+++ b/borg/borg.sh
@@ -19,7 +19,7 @@
 ##############################################################
 
 ##   Current Version
-    VERSION="v1.7.0"
+    VERSION="v1.8.0"
 
 ##      In First place: verify Input and packages precense
         #   Input Parameter
@@ -85,12 +85,11 @@
         FILE=${3}
         HOSTNAME=`hostname`
 
-        curl -v -4 -F \
-        "chat_id=${CHAT_ID}" \
-        "message_thread_id=${THREAD_ID}" \
-        -F document=@${FILE} \
+        curl -v -4 -F "chat_id=${CHAT_ID}" \
+        -F "message_thread_id=${THREAD_ID}" \
+        -F "document=@${FILE}" \
         -F caption="${HEADER}"$'\n'"        from: #${HOSTNAME}"$'\n'"${LINE1}" \
-        https://api.telegram.org/bot${API_KEY}/sendDocument
+        "https://api.telegram.org/bot${API_KEY}/sendDocument"
     }
 
     function package_exists(){
@@ -464,6 +463,7 @@
 
 ##############################################################
 #       MODIFICATION NOTES:
+#       2025-04-16  v1.8.0  Feature: API Telegram message_thread_id support
 #       2024-01-14  v1.7.0  Feature: Adding Emojis to Telegram messages
 #       2023-10-29  v1.6.0  Feature: Dinamic EXPORT of Variables
 #       2023-01-03  v1.5.2  Feature: TOTAL size (compact) in telegram notification/log

--- a/borg/borg.sh
+++ b/borg/borg.sh
@@ -63,6 +63,7 @@
     ENABLE_MESSAGE=`cat $1 | jq --raw-output '.Telegram.Enable'`
     CHAT_ID=`cat $1 | jq --raw-output '.Telegram.ChatID'`
     API_KEY=`cat $1 | jq --raw-output '.Telegram.APIkey'`
+    THREAD_ID=`cat $1 | jq --raw-output '.Telegram.ThreadId'`
 
 ##  Functions
     function TelegramSendMessage(){
@@ -72,6 +73,7 @@
         curl -s \
         --data parse_mode=HTML \
         --data chat_id=${CHAT_ID} \
+        --data message_thread_id=${THREAD_ID} \
         --data text="<b>${HEADER}</b>%0A      <i>from <b>#`hostname`</b></i>%0A%0A${2}%0A${3}%0A${4}%0A${5}%0A${6}%0A${7}%0A${8}%0A${9}%0A${10}%0A${11}%0A${12}%0A${13}%0A${14}%0A${15}%0A${16}%0A${17}%0A${18}%0A${19}%0A${20}%0A${21}%0A${22}%0A${23}%0A${24}%0A${25}%0A${26}%0A${27}%0A${28}%0A${29}%0A${30}%0A${31}%0A${32}%0A${33}%0A${34}%0A${35}%0A${36}" \
         "https://api.telegram.org/bot${API_KEY}/sendMessage"
     }
@@ -85,6 +87,7 @@
 
         curl -v -4 -F \
         "chat_id=${CHAT_ID}" \
+        "message_thread_id=${THREAD_ID}" \
         -F document=@${FILE} \
         -F caption="${HEADER}"$'\n'"        from: #${HOSTNAME}"$'\n'"${LINE1}" \
         https://api.telegram.org/bot${API_KEY}/sendDocument

--- a/borg/config.json
+++ b/borg/config.json
@@ -9,6 +9,7 @@
     "Telegram":{
         "Enable": true,
         "ChatID": "-123",
+        "ThreadId": "99",
         "APIkey": "123:ABC"
         },
     "Task": [


### PR DESCRIPTION
Introduce support for `message_thread_id` in the Telegram API, allowing messages to be sent to specific threads. Update the configuration to include a new `ThreadId` parameter and increment the version to v1.8.0.